### PR TITLE
Escape bucket name in a query if it starts with digit

### DIFF
--- a/apps/dalmatiner_frontend/priv/static/js/query.js
+++ b/apps/dalmatiner_frontend/priv/static/js/query.js
@@ -30,7 +30,10 @@ var QueryString = function () {
 if (QueryString.metric && QueryString.bucket) {
   var metric = decodeURIComponent(QueryString.metric);
   var bucket = decodeURIComponent(QueryString.bucket);
-  $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s")
+  if (bucket.match(/^[0-9]/)) {
+    bucket = "'" + bucket + "'";
+  }
+  $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s");
   q();
 } else if (QueryString.query) {
   var query = decodeURIComponent(QueryString.query);


### PR DESCRIPTION
Some of our buckets start with digit. Without escaping such bucket names query engine is failing. This pull requests fixes that by escaping bucket names if they start from digit.
