### PR TITLE
Move quert input to a proper HTML form

### DIFF
--- a/apps/dalmatiner_frontend/priv/static/index.html
+++ b/apps/dalmatiner_frontend/priv/static/index.html
@@ -36,13 +36,14 @@
       </section>
     </nav>
     <div class="row">
-      <div class="large-10 columns">
-        <input style="width: 98%" id="query" value="" />
-        <a href="" id="permalink"><i  class="fi-link"></i></a>
-      </div>
-      <div class="large-2 columns">
-        <a href="#" class="button tiny" onclick="q()">query</a>
-      </div>
+      <form id="queryfrom" action="/" method="get">
+        <div class="large-10 columns">
+          <input style="width: 98%" id="query" name="query" value="" />
+        </div>
+        <div class="large-2 columns">
+          <button type="submit" class="button tiny">query</a>
+        </div>
+      </form>
     </div>
     <div class="row">
       <div class="large-10 columns">

--- a/apps/dalmatiner_frontend/priv/static/js/query.js
+++ b/apps/dalmatiner_frontend/priv/static/js/query.js
@@ -1,8 +1,27 @@
 var c;
 Chart.defaults.global.responsive = true;
 
-$("#permalink").hide();
 $("#timewrap").hide();
+
+// If browser supports history pushStete, avoid reloading page on query change
+if (typeof(history) == "object" && typeof(history.pushState) == "function") {
+  $("#queryfrom").on("submit", function(e) {
+    var query = $("#query").val();
+    history.pushState({query: query}, document.title, "/?query=" + encodeURIComponent(query));
+    e.preventDefault();
+    q();
+  });
+  $(window).on("popstate", function(e) {
+    var m = window.location.search.match(/(\?|&)query=(.*)(&|$)/);
+    var query = m ? decodeURIComponent(m[2]) : "";
+    if (query) {
+      $("#query").val(query);
+      q();
+    } else {
+      window.location.reload();
+    }
+  });
+}
 
 var QueryString = function () {
   // This function is anonymous, is executed immediately and
@@ -33,7 +52,7 @@ if (QueryString.metric && QueryString.bucket) {
   $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s")
   q();
 } else if (QueryString.query) {
-  var query = decodeURIComponent(QueryString.query);
+  var query = decodeURIComponent(QueryString.query).replace(/\+/g, ' ');
   $("#query").val(query);
   q();
 }
@@ -44,8 +63,6 @@ function q() {
   var query = $("#query").val();
   msgpack.download("?q=" + query, {header: {accept:"application/x-msgpack"}}, function(res) {
     console.log("Fetching " + res.d[0].length + " elements in " + res.t / 1000 + "ms");
-    $("#permalink").attr("href", "/?query=" + encodeURIComponent(query))
-    $("#permalink").show();
     $("#time").text((res.t / 1000) + "ms");
     $("#timewrap").show();
     var idx = [];


### PR DESCRIPTION
I did this change mostly to be able to change a query and apply it with enter. I added also pushState support, so it will update url bar and will work properly with browser history.

This change made permalink obsolete because now query field and url should be in sync after every form submit (either via hitting enter, or button).

I find it much easier to play around with different queries with that approach.
