### PR TITLE
Escape bucket name in a query if it starts with digit

### DIFF
--- a/apps/dalmatiner_frontend/priv/static/js/query.js
+++ b/apps/dalmatiner_frontend/priv/static/js/query.js
@@ -30,7 +30,10 @@ var QueryString = function () {
 if (QueryString.metric && QueryString.bucket) {
   var metric = decodeURIComponent(QueryString.metric);
   var bucket = decodeURIComponent(QueryString.bucket);
-  $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s")
+  if (bucket.match(/^[0-9]/)) {
+    bucket = "'" + bucket + "'";
+  }
+  $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s");
   q();
 } else if (QueryString.query) {
   var query = decodeURIComponent(QueryString.query);

--- a/apps/dalmatiner_frontend/priv/static/js/query.js
+++ b/apps/dalmatiner_frontend/priv/static/js/query.js
@@ -30,7 +30,7 @@ var QueryString = function () {
 if (QueryString.metric && QueryString.bucket) {
   var metric = decodeURIComponent(QueryString.metric);
   var bucket = decodeURIComponent(QueryString.bucket);
-  if (bucket.match(/^[0-9]/)) {
+  if (! bucket.match(/^'.*'$/)) {
     bucket = "'" + bucket + "'";
   }
   $("#query").val("SELECT " + metric + " BUCKET " + bucket + " LAST 60s");


### PR DESCRIPTION
Recreating pull request #2 against test branch now.

Regarding your comment, we could add escaping all buckets, but we would still need to leave a check to not escape already escaped bucket name. You still end up with the same code complexity.
