### PR TITLE
Fix all handlers to match behaviour spec

### DIFF
--- a/apps/dalmatiner_frontend/src/dalmatiner_bucket_handler.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_bucket_handler.erl
@@ -1,7 +1,5 @@
-%% Feel free to use, reuse and abuse the code in this file.
-
-%% @doc POST echo handler.
 -module(dalmatiner_bucket_handler).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -32,5 +30,5 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, Bs, Req1, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.

--- a/apps/dalmatiner_frontend/src/dalmatiner_collection_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_collection_h.erl
@@ -1,4 +1,5 @@
 -module(dalmatiner_collection_h).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -29,5 +30,5 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, Bs, Req1, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.

--- a/apps/dalmatiner_frontend/src/dalmatiner_frontend_app.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_frontend_app.erl
@@ -59,9 +59,11 @@ start(_StartType, _StartArgs) ->
                            [{mimetypes, cow_mimetypes, web}]}}]}
                  ]),
     %% Name, NbAcceptors, TransOpts, ProtoOpts
-    cowboy:start_http(dalmatiner_http_listener, Listeners,
-                      [{port, Port}],
-                      [{env, [{dispatch, Dispatch}]}]),
+    {ok, _} = cowboy:start_http(dalmatiner_http_listener, Listeners,
+                                [{port, Port}],
+                                [{env, [{dispatch, Dispatch}]},
+                                 {max_keepalive, 5},
+                                 {timeout, 50000}]),
     dalmatiner_frontend_sup:start_link().
 
 stop(_State) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
@@ -1,7 +1,5 @@
-%% Feel free to use, reuse and abuse the code in this file.
-
-%% @doc POST echo handler.
 -module(dalmatiner_idx_handler).
+-behaviour(cowboy_http_handler).
 
 -export([send/4, content_type/1, init/3, handle/2, terminate/3]).
 
@@ -79,5 +77,5 @@ send(_, _D, Req, State) ->
     {ok, Req1} = cowboy_req:reply(415, Req),
     {ok, Req1, State}.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.

--- a/apps/dalmatiner_frontend/src/dalmatiner_key_handler.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_key_handler.erl
@@ -1,7 +1,5 @@
-%% Feel free to use, reuse and abuse the code in this file.
-
-%% @doc POST echo handler.
 -module(dalmatiner_key_handler).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -32,8 +30,8 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, D, Req2, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.
 
 get_metrics(Bucket, []) ->
     {ok, Ms} = ddb_connection:list(Bucket),

--- a/apps/dalmatiner_frontend/src/dalmatiner_metric_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_metric_h.erl
@@ -1,4 +1,5 @@
 -module(dalmatiner_metric_h).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -32,5 +33,5 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, Ms1, Req2, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.

--- a/apps/dalmatiner_frontend/src/dalmatiner_namespace_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_namespace_h.erl
@@ -1,4 +1,5 @@
 -module(dalmatiner_namespace_h).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -32,5 +33,5 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, Ns, Req3, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.

--- a/apps/dalmatiner_frontend/src/dalmatiner_tag_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_tag_h.erl
@@ -1,4 +1,5 @@
 -module(dalmatiner_tag_h).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -33,6 +34,6 @@ handle(Req, State) ->
             dalmatiner_idx_handler:send(ContentType, Ts, Req4, State)
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.
 

--- a/apps/dalmatiner_frontend/src/dalmatiner_value_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_value_h.erl
@@ -1,4 +1,5 @@
 -module(dalmatiner_value_h).
+-behaviour(cowboy_http_handler).
 
 -export([init/3, handle/2, terminate/3]).
 
@@ -35,5 +36,5 @@ handle(Req, State) ->
 
     end.
 
-terminate(_Reason, _Req, State) ->
-    {ok, State}.
+terminate(_Reason, _Req, _State) ->
+    ok.


### PR DESCRIPTION
This error was causing connection to break, just after request was served. Potentially it could have been also hiding some other errors in request handlers.

I have also marked handlers as modules implementing cowboy behaviour, so next time we should be warned by dialyzer about similar issues.
