### PR TITLE
MsgPack: Advance index pointer by appropriate amount for zero (as double)

### DIFF
--- a/apps/dalmatiner_frontend/priv/static/js/msgpack.base.js
+++ b/apps/dalmatiner_frontend/priv/static/js/msgpack.base.js
@@ -212,6 +212,7 @@ function decode() { // @return Mix:
                 exp  = (rv >> 20) & 0x7ff;  // 11bits
                 frac = rv & 0xfffff;        // 52bits - 32bits (high word)
                 if (!rv || rv === 0x80000000) { // 0.0 or -0.0
+                    readByte(that, 4);
                     return 0;
                 }
                 if (exp === 0x7ff) { // NaN or Infinity


### PR DESCRIPTION
After changes to mmath serialization, zeroes are encoded as 0.0.  This causes issues with the unpacking of the msgpack payload, as the pointer was not being advanced by enough bytes in the case that a zero is encountered.  
The following query would not work previously:

```
SELECT avg('fd4be66f-8703-412e-8ec9-9f230927b629'.'base'.'cpu' BUCKET 'fd', 2s) AS 'A', avg('fd4be66f-8703-412e-8ec9-9f230927b629'.'base'.'cpu' BUCKET 'fd', 2s) AS 'B' LAST 30s
```

This is because the offset would become corrupted by the time the second series is encountered.  JSON serialization is unaffected by these changes.
