### PR TITLE
CORS middleware

### DIFF
--- a/apps/dalmatiner_frontend/src/dalmatiner_bucket_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_bucket_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_collection_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_collection_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_cors_m.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_cors_m.erl
@@ -13,7 +13,7 @@
 execute(Req, Env) ->
     R1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>,
                                     <<"*">>, Req),
-    case cowboy_req:method(R1) of 
+    case cowboy_req:method(R1) of
         {<<"OPTIONS">>, R2} ->
             R3 = cowboy_req:set_resp_header(<<"access-control-allow-methods">>,
                                             <<"GET">>, R2),

--- a/apps/dalmatiner_frontend/src/dalmatiner_cors_m.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_cors_m.erl
@@ -1,0 +1,28 @@
+-module(dalmatiner_cors_m).
+-behaviour(cowboy_middleware).
+
+-export([execute/2]).
+
+%%
+%% CORS middleware
+%% =====================================
+
+-spec execute(cowboy_req:req(), [{atom(), any()}]) ->
+                     {ok, cowboy_req:req(), [{atom(), any()}]} |
+                     {halt, cowboy_req:req()}.
+execute(Req, Env) ->
+    R1 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>,
+                                    <<"*">>, Req),
+    case cowboy_req:method(R1) of 
+        {<<"OPTIONS">>, R2} ->
+            R3 = cowboy_req:set_resp_header(<<"access-control-allow-methods">>,
+                                            <<"GET">>, R2),
+            R4 = cowboy_req:set_resp_header(<<"access-control-allow-headers">>,
+                                            <<"Authorization">>, R3),
+            R5 = cowboy_req:set_resp_header(<<"access-control-max-age">>,
+                                            <<"3600">>, R4),
+            {ok, R6} = cowboy_req:reply(200, R5),
+            {halt, R6};
+        {_, R2} ->
+            {ok, R2, Env}
+    end.

--- a/apps/dalmatiner_frontend/src/dalmatiner_frontend_app.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_frontend_app.erl
@@ -75,7 +75,11 @@ start(_StartType, _StartArgs) ->
     %% Name, NbAcceptors, TransOpts, ProtoOpts
     {ok, _} = cowboy:start_http(dalmatiner_http_listener, Listeners,
                                 [{port, Port}],
-                                [{env, [{dispatch, Dispatch}]},
+                                [{env, [{dispatch, Dispatch}]}
+                                 {middlewares,
+                                  [cowboy_router,
+                                   dalmatiner_cors_m,
+                                   cowboy_handler]},
                                  {max_keepalive, 5},
                                  {timeout, 50000}]),
     dalmatiner_frontend_sup:start_link().

--- a/apps/dalmatiner_frontend/src/dalmatiner_function_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_function_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
@@ -10,9 +10,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(<<"access-control-allow-origin">>,
-                                      <<"*">>, Req),
-    case cowboy_req:qs_val(<<"q">>, Req0) of
+    case cowboy_req:qs_val(<<"q">>, Req) of
         {undefined, Req1} ->
             F = fun (Socket, Transport) ->
                         File = code:priv_dir(dalmatiner_frontend) ++

--- a/apps/dalmatiner_frontend/src/dalmatiner_key_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_key_h.erl
@@ -11,9 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-    {[Bucket | Path], Req1} = cowboy_req:path_info(Req0),
+    {[Bucket | Path], Req1} = cowboy_req:path_info(Req),
     {ContentType, Req2} = dalmatiner_idx_handler:content_type(Req1),
     case ContentType of
         html ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_metric_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_metric_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_namespace_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_namespace_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_tag_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_tag_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->

--- a/apps/dalmatiner_frontend/src/dalmatiner_value_h.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_value_h.erl
@@ -11,10 +11,7 @@ init(_Transport, Req, []) ->
 
 -dialyzer({no_opaque, handle/2}).
 handle(Req, State) ->
-    Req0 = cowboy_req:set_resp_header(
-             <<"access-control-allow-origin">>, <<"*">>, Req),
-
-    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req0),
+    {ContentType, Req1} = dalmatiner_idx_handler:content_type(Req),
     case ContentType of
         html ->
             F = fun (Socket, Transport) ->


### PR DESCRIPTION
If you run a request across domains with non standard header (like 'Accept: application/x-msgpack'), browser will run OPTIONS pre-flight check.

This pull requests add supports of such requests in Cowboy middle-ware. As a part of this change I have move setting headers from various handlers to one middle-ware, so it is easier to centrally manage all CORS related headers.
