### PR TITLE
Make sudo set user HOME folder when changing user

### DIFF
--- a/rel/files/dalmatinerfe
+++ b/rel/files/dalmatinerfe
@@ -13,7 +13,7 @@ RUNNER_USER={{run_user}}
 
 # Make sure this script is running as the appropriate user
 if [ ! -z "$RUNNER_USER" ] && [ `whoami` != "$RUNNER_USER" ]; then
-    exec sudo -u $RUNNER_USER $0 $@
+    exec sudo -H -u $RUNNER_USER $0 $@
 fi
 
 # Make sure CWD is set to runner base dir


### PR DESCRIPTION
This fixes issues with start-up script complaining about not being able to access /root/.erlang when called by user.
