### PR TITLE
Return 404 status code when there is no results

### DIFF
--- a/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
+++ b/apps/dalmatiner_frontend/src/dalmatiner_idx_handler.erl
@@ -27,9 +27,10 @@ handle(Req, State) ->
                 {_, {error, E}} ->
                     Error = list_to_binary(dqe:error_string({error, E})),
                     lager:warning("Error in query [~s]: ~p", [Q, E]),
-                    {ok, ReqR1} =
-                        cowboy_req:reply(400, [], Error, ReqR),
-                    {ok, ReqR1, State};
+                    StatusCode = error_code(E),
+                    {ok, Req2} =
+                        cowboy_req:reply(StatusCode, [], Error, Req1),
+                    {ok, Req2, State};
                 {T, {ok, Start, R2}} ->
                     D = encode_reply(Start, T, R2),
                     {ContentType, ReqR1} = content_type(ReqR),
@@ -88,6 +89,11 @@ content_type_([{{<<"application">>, <<"x-msgpack">>, _}, _, _} | _]) ->
     msgpack;
 content_type_([_ | R]) ->
     content_type_(R).
+
+error_code(no_results) ->
+    404;
+error_code(_) ->
+    400.
 
 send(json, D, Req, State) ->
     {ok, Req1} =


### PR DESCRIPTION
This allow us to differentiate between situations when query is badly formed and when query is semantically valid, but no data matches it. I think it is useful to have such separation.